### PR TITLE
Added support for SSL parameter control through the use of a config file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.rvmrc
+Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .rvmrc
 Gemfile.lock
+pkg/*

--- a/README.md
+++ b/README.md
@@ -31,6 +31,35 @@ or
 
     $ sudo tunnels 127.0.0.1:443 127.0.0.1:3000
 
+Config File
+-----------
+
+When using the verbose format for specifying host and port, you may
+append a third argument with the location of a configuration file
+
+    $ sudo tunnels 443 80 my_config.yml
+
+The format for the configuration file is simple:
+
+    server:
+      certificate_file: certs/server.crt
+      private_key_file: certs/server.key
+    client:
+      verify: true
+      certificate_ca_file: certs/server-ca.crt
+
+All paths in the configuration file are relative to the file itself and
+will be normalized by the config file reader.
+
+**NOTE:** Due to a [lack of support][bug] for [RFC 5746][] support in
+Safari, enabling peer verification will only work in Firefox, Chrome,
+IE and Opera. Until Safari fixes this support, if you need client-side
+certificates to work within Safari in your development environment you
+are better looking for a different option.
+
+[bug]: http://openradar.appspot.com/8696868
+[RFC 5746]: http://tools.ietf.org/html/rfc5746
+
 Copyright
 ---------
 

--- a/bin/tunnels
+++ b/bin/tunnels
@@ -1,13 +1,15 @@
 #!/usr/bin/env ruby
 require 'tunnels'
-unless ARGV.size == 0 || ARGV.size == 2
+unless ARGV.size == 0 || (2..5).include?(ARGV.size)
   puts <<-D
 Usage:
-    tunnels [from to]
+    tunnels [from to] [cert_chain_file] [private_key_file] [verify_peer]
+    tunnels from to [cert_chain_file [private_key_file [verify_peer]]]
 
 Examples:
     tunnels 443 3000
     tunnels localhost:443 localhost:3000
+    tunnels 443 80 /path/to/chain.crt /path/to/private.key true
 
   D
   exit!

--- a/bin/tunnels
+++ b/bin/tunnels
@@ -1,15 +1,14 @@
 #!/usr/bin/env ruby
 require 'tunnels'
-unless ARGV.size == 0 || (2..5).include?(ARGV.size)
+unless ARGV.size == 0 || (2..3).include?(ARGV.size)
   puts <<-D
 Usage:
-    tunnels [from to] [cert_chain_file] [private_key_file] [verify_peer]
-    tunnels from to [cert_chain_file [private_key_file [verify_peer]]]
+    tunnels [from to [config_file]]
 
 Examples:
     tunnels 443 3000
     tunnels localhost:443 localhost:3000
-    tunnels 443 80 /path/to/chain.crt /path/to/private.key true
+    tunnels 443 80 /path/to/config.yml
 
   D
   exit!

--- a/lib/tunnels.rb
+++ b/lib/tunnels.rb
@@ -1,25 +1,22 @@
 require "tunnels/version"
 require "eventmachine"
+require "yaml"
+require "openssl"
 
-# most of code is from [thin-glazed](https://github.com/freelancing-god/thin-glazed).
+# Most of code is from [thin-glazed](https://github.com/freelancing-god/thin-glazed).
 # Copyright © 2012, Thin::Glazed was a Rails Camp New Zealand project, and is developed
 # and maintained by Pat Allan. It is released under the open MIT Licence.
 
 module Tunnels
-  def self.run!(from = '127.0.0.1:443', to = '127.0.0.1:80', cert_chain = nil, private_key = nil, verify_peer = false)
+  def self.run!(from = '127.0.0.1:443', to = '127.0.0.1:80', config_file = nil)
     from_host, from_port = parse_host_str(from)
     to_host, to_port = parse_host_str(to)
     puts "#{from_host}:#{from_port} --(--)--> #{to_host}:#{to_port}"
 
-    # Construct the SSL options required by EventMachine::Connection#start_tls
-    ssl_options = {
-      :cert_chain_file => cert_chain,
-      :private_key_file => private_key,
-      :verify_peer => verify_peer
-    }
+    options = parse_config_file config_file
 
     EventMachine.run do
-      EventMachine.start_server(from_host, from_port, HttpsProxy, to_port, ssl_options)
+      EventMachine.start_server(from_host, from_port, HttpsProxy, to_port, options)
       puts "Ready :)"
     end
   rescue => e
@@ -35,6 +32,10 @@ module Tunnels
     else
       [parts[0], parts[1].to_i]
     end
+  end
+
+  def self.parse_config_file(file)
+    { "config_file" => file }.merge YAML::load(File.read file) rescue {}
   end
 
   class HttpClient < EventMachine::Connection
@@ -95,9 +96,26 @@ module Tunnels
   end
 
   class HttpsProxy < HttpProxy
-    def initialize(client_port, ssl_options)
+
+    def initialize(client_port, options)
       super client_port
-      @ssl_options = ssl_options
+
+      base_path = File.dirname File.expand_path options['config_file']
+
+      @ssl_options = {
+        :cert_chain_file  => File.join(base_path, options['server']['certificate_file']),
+        :private_key_file => File.join(base_path, options['server']['private_key_file']),
+        :verify_peer      => options['client']['verify']
+      }
+
+      # START: Debug
+      server_cert = load_cert_file File.join(base_path, options['server']['certificate_file'])
+      puts "Server certificate: " + server_cert.subject.to_s
+      # END: Debug
+
+      unless options['client']['certificate_ca_file'].nil?
+        @ssl_ca = load_cert_file File.join(base_path, options['client']['certificate_ca_file'])
+      end
     end
 
     def post_init
@@ -105,7 +123,48 @@ module Tunnels
     end
 
     def receive_data(data)
-      super data.gsub(/\r\n\r\n/, "\r\nX_FORWARDED_PROTO: https\r\n\r\n")
+      header_string = headers.collect { |k, v| k.to_s.upcase + ": " + v }.join "\r\n"
+
+      # START: Debug
+      puts "Sending headers:\n" + header_string
+      # END: Debug
+
+      super data.gsub(/\r\n\r\n/, "\r\n#{header_string}\r\n\r\n")
+    end
+
+    # Called for every certificate in the chain provided by a user if :verify_peer => true was
+    # passed to #start_tls.
+    # cert - String of the certificate in PEM format.
+    def ssl_verify_peer(cert)
+      puts "Verify Peer"
+      peer = load_cert cert
+      verified = peer.verify @ssl_ca.public_key
+
+      # START: Debug
+      puts "Issuer subject: " + @ssl_ca.subject.to_s
+      puts "Peer issuer:    " + peer.issuer.to_s
+      puts "Peer subject:   " + peer.subject.to_s
+      puts "Peer verified:  " + verified.inspect
+      # END: Debug
+
+      headers[:ssl_client_s_dn] = peer.subject.to_s
+      headers[:ssl_client_verify] = if verified then "SUCCESS" else "FAILED" end
+
+      true
+    end
+
+    private
+
+    def load_cert(pem_string)
+      OpenSSL::X509::Certificate.new(pem_string)
+    end
+
+    def load_cert_file(path)
+      load_cert File.read(path)
+    end
+
+    def headers
+      @headers ||= { :x_forwarded_proto => 'https', :ssl_client_verify => 'NONE' }
     end
   end
 end

--- a/lib/tunnels.rb
+++ b/lib/tunnels.rb
@@ -96,7 +96,7 @@ module Tunnels
 
   class HttpsProxy < HttpProxy
     def initialize(client_port, ssl_options)
-      super(client_port)
+      super client_port
       @ssl_options = ssl_options
     end
 


### PR DESCRIPTION
An optional third parameter on the command line specifies the path to the configuration file. Four parameters specify the server and client certificate and key specifics that allow the system to function.

Two notes:
- First, peer verification does not work on Safari due to a bug listed in the README
- Second, I have not added in a log of checking to make sure the parameters were passed properly. Definitely a TODO.

Thanks,
Seth
