### PR TITLE
Adds a launchd Property List File.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Run
 ---
 
     $ sudo tunnels
+    
+If you're on a Mac and wanna have tunnels run all the time, load it via launchctl from `/Library/LaunchAgents`:
+
+    $ launchctl load jugyo.tunnels.plist
+   
+or use [LaunchRocket](https://github.com/jimbojsb/launchrocket), but don't forget to check the "As Root" option.
 
 If you are using rvm:
 

--- a/jugyo.tunnels.plist
+++ b/jugyo.tunnels.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>Label</key>
+        <string>jugyo.tunnels</string>
+        <key>ProgramArguments</key>
+        <array>
+                <string>/usr/bin/env</string>
+                <string>ruby</string>
+                <string>-rtunnels</string>
+                <string>-eTunnels.run!</string>
+        </array>
+        <key>KeepAlive</key>
+        <true/>
+        <key>RunAtLoad</key>
+        <true/>
+        <!-- Uncomment if you encounter problems.
+        <key>StandardOutPath</key>
+        <string>/var/log/tunnels.log</string>
+        <key>StandardErrorPath</key>
+        <string>/var/log/tunnels.log</string>
+        <key>Debug</key>
+        <true/>
+        -->
+</dict>
+</plist>


### PR DESCRIPTION
Allows tunnels to start with OS X and keep it running in background
without having to start it manually.

![Tunnels in LaunchRocket](https://cloud.githubusercontent.com/assets/14321/3827359/7c60c9ac-1d6d-11e4-95d1-5f8c559e03d9.png)
